### PR TITLE
Pull request fixing "Error using nm-file-secret-agent to provide wifi password"

### DIFF
--- a/src/dbus_server.rs
+++ b/src/dbus_server.rs
@@ -191,9 +191,16 @@ fn get_secret(
     let conn_type = connection["connection"]["type"]
         .as_str()
         .context("Connection property connection.type is not a string")?;
-    let iface_name = connection["connection"]["interface-name"]
-        .as_str()
-        .context("Connection property connection.interface-name is not a string")?;
+    // The interface name is not always present. If it is present, it should be a string.
+    let iface_name = if let Some(iface) = connection["connection"].get("interface-name") {
+        Some(
+            iface
+                .as_str()
+                .context("Connection property connection.interface-name is not a string")?,
+        )
+    } else {
+        None
+    };
 
     tracing::info!(
         connectionId = conn_id,

--- a/src/dbus_server.rs
+++ b/src/dbus_server.rs
@@ -38,6 +38,7 @@ enum GetSecretsFlags {
     #[allow(dead_code)]
     UserRequested = 0x4,
     /// indicates that WPS enrollment is active with PBC method. The agent may suggest that the user pushes a button on the router instead of supplying a PSK.
+    #[allow(dead_code)]
     WbsPbcActive = 0x8,
 }
 
@@ -208,9 +209,6 @@ fn get_secret(
     // abort on unsupported flags
     if (flags & GetSecretsFlags::RequestNew as u32) == GetSecretsFlags::RequestNew as u32 {
         panic!("NetworkManager requested new credentials which cannot be provided by this agent");
-    }
-    if (flags & GetSecretsFlags::WbsPbcActive as u32) == GetSecretsFlags::WbsPbcActive as u32 {
-        panic!("NetworkManager requested a WPA action to be performed which is not supported by this agent");
     }
 
     // fetch matching secret entries

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -62,7 +62,7 @@ impl MappingConfig {
         conn_id: &str,
         conn_uuid: &str,
         conn_type: &str,
-        iface_name: &str,
+        iface_name: Option<&str>,
         setting_name: &str,
     ) -> anyhow::Result<Vec<(String, String)>> {
         self.entries
@@ -88,12 +88,14 @@ impl MappingConfig {
                     return false;
                 }
 
-                if entry
-                    .match_iface
-                    .as_ref()
-                    .is_some_and(|val| val != iface_name)
-                {
-                    return false;
+                if let Some(iface_name) = iface_name {
+                    if entry
+                        .match_iface
+                        .as_ref()
+                        .is_some_and(|val| val != iface_name)
+                    {
+                        return false;
+                    }
                 }
 
                 if entry


### PR DESCRIPTION
This pull request provides two changes, which fix #2.

* Remove the check (and therefore the panic) when the WPS_PBC_ACTIVE flag is set. This seems justified as the agent is still allowed to provide the PSK without user interaction.
* Make the interface name optional. Apparently, the interface name is not provided always. Hence, I made it optional to accommodate these cases. 